### PR TITLE
Robusteness to allow carving a full disk

### DIFF
--- a/scripts/parseusn.py
+++ b/scripts/parseusn.py
@@ -260,7 +260,8 @@ def main(argv):
     it.close()
     ot.close()
 
-    os.unlink("{}.tmp".format(infile))
+    if args.tempfile:
+        os.unlink(tmpname)
 
     exit(0)
 


### PR DESCRIPTION
The old implementation is not able to handle nonsense input. This makes it difficult to handle large blobs of (unallocated) data.

When feeding e.g. a disk image it makes no sense to first copy the data.

The current implementation skips to page boundaries. As a drawback records in file slack will not be found. When carving a full disk I think this is an acceptable disadvantage. The number of false positives would also increase and stepping/scanning in 0x4 bytes is seriously slow.

